### PR TITLE
Fix scraping bugs in worldometers

### DIFF
--- a/covid/worldometers/covid.py
+++ b/covid/worldometers/covid.py
@@ -68,8 +68,11 @@ class Covid:
             list: List of country data
         """
         return [
-            CovidModel(**dict(zip(self.__headers, self.__format(val)))).dict()
+            CovidModel(
+                **dict(zip(self.__headers, self.__format(val)))
+            ).model_dump()
             for val in self.__data.values()
+            if val[0] != ""
         ]
 
     def get_status_by_country_name(self, country_name: str) -> dict:

--- a/covid/worldometers/covid.py
+++ b/covid/worldometers/covid.py
@@ -58,7 +58,9 @@ class Covid:
         Returns:
             list: output formatted list
         """
-        _list = [val.strip().replace(",", "") for val in _list]
+        _list = [
+            val.strip().replace(",", "").replace("+", "") for val in _list
+        ]
         return [val if val and val != "N/A" else 0 for val in _list]
 
     def get_data(self) -> list:


### PR DESCRIPTION
I found two bugs when trying to scrape worldometers with this package. 

* There was an empty line # in the countries table (world), I think - it's been a while since I wrote that, so I don't completely remember what was the issue faced exactly.
* The new cases/new deaths are presented as `+number` so they could not directly parsed as integers.


This MR fixes these two issues.